### PR TITLE
Remove reference to past date in future tense along with outdated specification

### DIFF
--- a/protocol/governance/proposal-types.md
+++ b/protocol/governance/proposal-types.md
@@ -20,7 +20,7 @@ The function of the text proposal is to allow proposals that do not fit the defi
 The full process of getting a new asset to be fully operational on the Mirror Protocol is described [here](whitelist-procedure.md).
 {% endhint %}
 
-The function of this proposal is to start a poll to whitelist a new asset. Given that this is a simple text proposal, there are a few fields that need to be filled. The `Asset Name`, `Ticker`, `Listed Exchange`, and `Reason for listing` are required. Due to the limitations on the length of the description field of the underlying smart contracts, the current maximum length is 64 bytes \(will be increased to 1024 bytes on December 31, 2020\). It is suggested that additional information be added on a separate web page and linked to using the `Information Link` field.
+The function of this proposal is to start a poll to whitelist a new asset. Given that this is a simple text proposal, there are a few fields that need to be filled. The `Asset Name`, `Ticker`, `Listed Exchange`, and `Reason for listing` are required. The length of the description field is limited to 1024 bytes. It is suggested that additional information be added on a separate web page and linked to using the `Information Link` field.
 
 ![Example Whitelist Poll](../../.gitbook/assets/2020-12-21-6.57.30.png)
 


### PR DESCRIPTION
Discussion of a coming field length change referenced Dec 2020 as a future date.  

That time has passed.  Update to simply reflect the current state.

Leaving it worded "will change .. " and then a past date is confusing at best.   